### PR TITLE
Small fixes and support for multiple mirrors with different mirror lists

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -4,18 +4,23 @@ driver_config:
   require_chef_omnibus: true
 
 platforms:
+- name: ubuntu-10.04
+  run_list:
+  - "recipe[apt]"
 - name: ubuntu-12.04
-  driver_config:
-    box: opscode-ubuntu-12.04
-    box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/opscode_ubuntu-12.04_provisionerless.box
-  run_list: ["recipe[apt]"]
-#- name: ubuntu-10.04
-#  driver_config:
-#    box: opscode-ubuntu-10.04
-#    box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/opscode_ubuntu-10.04_provisionerless.box
+  run_list:
+  - "recipe[apt]"
+- name: ubuntu-14.04
+  run_list:
+  - "recipe[apt]"
 
 suites:
 - name: default
-  run_list: ["recipe[apt-mirror]","recipe[apt-mirror::nginx]"]
-  attributes: {}
-  data_bags_path: "data_bags"
+  run_list:
+  - recipe[apt-mirror]
+  - recipe[apt-mirror::nginx]
+  attributes:
+    apt-mirror:
+      data_bags:
+      - "mirror1"
+      - "mirror2"

--- a/Berksfile
+++ b/Berksfile
@@ -3,5 +3,5 @@ site :opscode
 metadata
 
 group :integration do
-  cookbook "apt"
+  cookbook 'apt'
 end

--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -1,11 +1,9 @@
-{
-  "sha": "72f348f5a2c446733a2da44b08113800b63b54aa",
-  "sources": {
-    "apt-mirror": {
-      "path": "."
-    },
-    "apt": {
-      "locked_version": "2.1.1"
-    }
-  }
-}
+DEPENDENCIES
+  apt
+  apt-mirror
+    path: .
+    metadata: true
+
+GRAPH
+  apt (2.7.0)
+  apt-mirror (0.1.2)

--- a/README.md
+++ b/README.md
@@ -7,14 +7,16 @@ repository mirrors for Ubuntu and for additional APT repositories.
 Requirements
 ------------
 
-* Ubuntu 10.04 / Ubuntu 12.04
+* Ubuntu 10.04 / Ubuntu 12.04 / Ubuntu 14.04
 * Data Bag named apt-mirror
 
 ```json
 {
   "id": "sensu",
-  "source": "deb  http://repos.sensuapp.org/apt sensu main",
-  "fqdn": "repos.sensuapp.org"
+  "source": [
+    "deb  http://repos.sensuapp.org/apt sensu main",
+    "deb http://archive.ubuntu.com/ubuntu trusty main restricted universe multiverse"
+  ]
 }
 ```
 
@@ -23,15 +25,16 @@ Attributes
 
 *  node['apt-mirror']['base_path'] - Base path for mirror files.
 *  node['apt-mirror']['nodearch'] - To specify which platform arch to mirror. Default is amd64.
-*  node['apt-mirror']['run_postmirror'] - 
+*  node['apt-mirror']['run_postmirror'] -
 *  node['apt-mirror']['nthreads'] - Set number of threads to use for downloading packages.
-*  node['apt-mirror']['_tilde'] - 
+*  node['apt-mirror']['_tilde'] -
 *  node['apt-mirror']['cron']['active'] - Have Chef schedule to run in cron.
 *  node['apt-mirror']['cron']['minute'] - Minute
 *  node['apt-mirror']['cron']['hour'] - Hour
 *  node['apt-mirror']['cron']['day'] - Day.
 *  node['apt-mirror']['cron']['weekday'] - Weekday. Default is everyday.
 *  node['apt-mirror']['nginx']['port'] - Set port for nginx to run.
+*  node['apt-mirror']['data_bags'] - which data_bags to use, default is empty
 
 Usage
 -----

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -8,3 +8,4 @@ default['apt-mirror']['cron']['minute']     = 0
 default['apt-mirror']['cron']['hour']       = 5
 default['apt-mirror']['cron']['day']        = '*'
 default['apt-mirror']['cron']['weekday']    = '*'
+default['apt-mirror']['data_bags']          = []

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,9 +1,9 @@
-name             'apt-mirror'
-maintainer       'Heavy Water Operations'
+name 'apt-mirror'
+maintainer 'Heavy Water Operations'
 maintainer_email 'aaron@hw-ops.com'
-license          'Apache 2.0'
-description      'Installs/Configures apt-mirror'
+license 'Apache 2.0'
+description 'Installs/Configures apt-mirror'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.2'
+version '0.1.2'
 
-supports  'ubuntu'
+supports 'ubuntu'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,47 +17,52 @@
 # limitations under the License.
 #
 
-package "apt-mirror" do
+package 'apt-mirror' do
   action :install
 end
 
 directory node['apt-mirror']['base_path'] do
-  owner "root"
-  group "root"
-  mode  0755
+  owner 'root'
+  group 'root'
+  mode 0755
   recursive true
 end
 
-repository_locations = data_bag('apt-mirror').map do |mirror|
-  data_bag_item('apt-mirror', mirror)["source"]
+repository_locations = []
+
+node['apt-mirror']['data_bags'].each do |bag|
+  repos = data_bag_item('apt-mirror', bag)
+  repos['source'].each do |repo|
+    repository_locations.push(repo)
+  end
 end
 
 template '/etc/apt/mirror.list' do
   source 'mirror.erb'
-  mode    '0644'
-  owner   'root'
-  group   'root'
+  mode '0644'
+  owner 'root'
+  group 'root'
   variables(
-    :base_path => node['apt-mirror']['base_path'],
-    :defaultarch => node['apt-mirror']['defaultarch'],
-    :run_postmirror => node['apt-mirror']['run_postmirror'],
-    :nthreads => node['apt-mirror']['nthreads'],
-    :_tilde => node['apt-mirror']['_tilde'],
-    :repository_locations => repository_locations
+    base_path: node['apt-mirror']['base_path'],
+    defaultarch: node['apt-mirror']['defaultarch'],
+    run_postmirror: node['apt-mirror']['run_postmirror'],
+    nthreads: node['apt-mirror']['nthreads'],
+    _tilde: node['apt-mirror']['_tilde'],
+    repository_locations: repository_locations
   )
 end
 
 if node['apt-mirror']['cron']['active']
-  cron "update_repository_mirrors" do
-    minute  node['apt-mirror']['cron']['minute']
-    hour    node['apt-mirror']['cron']['hour']
-    day     node['apt-mirror']['cron']['day']
+  cron 'update_repository_mirrors' do
+    minute node['apt-mirror']['cron']['minute']
+    hour node['apt-mirror']['cron']['hour']
+    day node['apt-mirror']['cron']['day']
     weekday node['apt-mirror']['cron']['weekday']
-    command "/usr/bin/apt-mirror > /var/spool/apt-mirror/var/cron.log"
-    action  :create
+    command '/usr/bin/apt-mirror > /var/spool/apt-mirror/var/cron.log'
+    action :create
   end
 else
-  cron "update_repository_mirrors" do
-    action  :delete
+  cron 'update_repository_mirrors' do
+    action :delete
   end
 end

--- a/recipes/nginx.rb
+++ b/recipes/nginx.rb
@@ -26,15 +26,15 @@ repository_information = data_bag('apt-mirror').map do |mirror|
 end
 
 template '/etc/nginx/sites-available/apt-mirrors' do
-  source  'nginx-mirrors.erb'
-  mode    '0644'
-  owner   'root'
-  group   'root'
+  source 'nginx-mirrors.erb'
+  mode '0644'
+  owner 'root'
+  group 'root'
   variables(
-    :port => node['apt-mirror']['nginx']['port'],
-    :server_name => node['fqdn'],
-    :mirror_path => File.join(node['apt-mirror']['base_path'], "/mirror/"),
-    :repository_information => repository_information
+    port: node['apt-mirror']['nginx']['port'],
+    server_name: node['fqdn'],
+    mirror_path: File.join(node['apt-mirror']['base_path'], '/mirror/'),
+    repository_information: repository_information
   )
 end
 
@@ -44,6 +44,6 @@ link '/etc/nginx/sites-enabled/apt-mirrors' do
 end
 
 service 'nginx' do
-  supports :status => true, :restart => true, :reload => true
+  supports status: true, restart: true, reload: true
   action :enable
 end

--- a/test/integration/data_bags/apt-mirror/mirror1.json
+++ b/test/integration/data_bags/apt-mirror/mirror1.json
@@ -1,5 +1,11 @@
 {
   "id": "mirror1",
-  "source": "deb  http://ppa.launchpad.net/ubuntu-clamav/ppa/ubuntu precise main",
-  "fqdn": "ppa.launchpad.net"
+  "source": [
+    "deb http://archive.ubuntu.com/ubuntu trusty main restricted universe multiverse",
+    "deb http://archive.ubuntu.com/ubuntu trusty-security main restricted universe multiverse",
+    "deb http://archive.ubuntu.com/ubuntu trusty-updates main restricted universe multiverse",
+    "deb-src http://archive.ubuntu.com/ubuntu trusty main restricted universe multiverse",
+    "deb-src http://archive.ubuntu.com/ubuntu trusty-security main restricted universe multiverse",
+    "deb-src http://archive.ubuntu.com/ubuntu trusty-updates main restricted universe multiverse"
+  ]
 }

--- a/test/integration/data_bags/apt-mirror/mirror2.json
+++ b/test/integration/data_bags/apt-mirror/mirror2.json
@@ -1,5 +1,7 @@
 {
   "id": "mirror2",
-  "source": "deb  http://repo.percona.com/apt precise main",
-  "fqdn": "repo.percona.com"
+  "source": [
+    "deb http://repo.percona.com/apt trusty main",
+    "deb-src http://repo.percona.com/apt trusty main"
+  ]
 }

--- a/test/integration/data_bags/apt-mirror/mirror3.json
+++ b/test/integration/data_bags/apt-mirror/mirror3.json
@@ -1,5 +1,0 @@
-{
-  "id": "mirror3",
-  "source": "deb  http://repos.sensuapp.org/apt sensu main",
-  "fqdn": "repos.sensuapp.org"
-}

--- a/test/integration/data_bags/apt-mirror/mirror4.json
+++ b/test/integration/data_bags/apt-mirror/mirror4.json
@@ -1,5 +1,0 @@
-{
-  "id": "mirror4",
-  "source": "deb  https://swsp-ruby-193p429.s3.amazonaws.com/ precise main",
-  "fqdn": "swsp-ruby-193p429.s3.amazonaws.com"
-}

--- a/test/integration/data_bags/apt-mirror/mirror5.json
+++ b/test/integration/data_bags/apt-mirror/mirror5.json
@@ -1,5 +1,0 @@
-{
-  "id": "mirror5",
-  "source": "deb  http://downloads-distro.mongodb.org/repo/debian-sysvinit dist 10gen",
-  "fqdn": "downloads-distro.mongodb.org"
-}

--- a/test/integration/data_bags/apt-mirror/mirror6.json
+++ b/test/integration/data_bags/apt-mirror/mirror6.json
@@ -1,5 +1,0 @@
-{
-  "id": "mirror6",
-  "source": "deb  http://ppa.launchpad.net/rwky/redis/ubuntu precise main",
-  "fqdn": "ppa.launchpad.net"
-}


### PR DESCRIPTION
- data bag integration changed, so not all mirrors in an environment have to use the same mirrors
- added ubuntu 14.04 to kitchen file
- rubocop fixes
- removed some testing data_bags
- removed fqdn from test data bags, not needed

Kitchen run was fine, I did only test ubuntu 14.04 for full functionality.
